### PR TITLE
refactor(docs,cli): update support code around the HTTP interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,29 @@
 
 Uses [`whisper.cpp`](https://github.com/ggerganov/whisper.cpp) by way of [`whisper-rs`](https://github.com/tazz4843/whisper-rs).
 
-> ⚠️ DISCLAIMER - this probably does not work with MBP mics. Whisper expects 16k
-> sample rate, but Macbook mics don't have that option and I'm not handling
-> downsampling yet. Use a mic that directly supports 16k in the meantime.
-
-Bind to hotkeys as you prefer. I'm running the server as a daemon with `launchd`.
+Bind requests to hotkeys as you prefer. I'm running the server as a daemon with `launchd`.
 
 If you don't already have a `whisper.cpp`-compatible model, follow that project's [quick-start instructions](https://github.com/ggerganov/whisper.cpp#quick-start) to get one.
 
 Start the server:
 `./run.sh macbook ggml-base.en.bin /tmp/whisper.sock`
 
-Start recording:
+Start recording: `curl -X POST -H "Content-Type: application/json" -d "$body" "http://127.0.0.1:8088/voice/$1"`
 
-`$ echo -n "{\"type\": \"start\"}" | socat -t2 - /tmp/whisper.sock`
+Example request body:
+```json
+{
+  // partial name matches OK
+  "input_device": "MacBook Pro Microphone",
 
-Output: `{ "type": "ack" }`
+  // optional
+  "sample_rate": 44100,
+}
+```
+Response: `{ "type": "ack" }`
 
-Stop recording:
-
-`echo -n "{\"type\": \"stop\"}" | socat -t2 - /tmp/whisper.sock`
-
-Output:
+Stop recording: `curl -X POST http://localhost:8088/voice/stop`
+Example response:
 ```json
 {
   "data": {
@@ -36,4 +37,4 @@ Output:
 }
 ```
 
-Note: the modes that you get back in the output are just metadata. Your client application that handles reading from the socket should also handle processing the transcription differently based on the mode.
+Note: the modes that you get back in the output are just metadata. Your client application that talks to the server should also handle processing the transcription differently based on the mode.

--- a/run.sh
+++ b/run.sh
@@ -14,18 +14,13 @@ fi
 # So you'll still see those in the log output, even if you're suppressing.
 export RUST_LOG=whisper_sys_log=error,voice=debug
 
-# Can be a substring of the input device name you want to use? For instance,
-# "macbook" for "MacBook Pro Microphone".
-device_name="$1"
-
 # See the whisper.cpp repo for details on how to get a model. I recommend using
 # base or small for best results.
 model_path="$2"
 
-# The Unix socket the program will read and write to.
-socket_path="$3"
+# The address on which the HTTP server should listen (e.g. localhost:PORT)
+addr="$3"
 
 ./voice run-daemon \
-    --socket-path "$socket_path" \
-    --model       "$model_path" \
-    --device-name "$device_name"
+    --serve       "$addr"
+    --model       "$model_path"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -151,7 +151,9 @@ impl Daemon {
         tx_worker.join().unwrap()?;
 
         // remove socket
-        std::fs::remove_file(&self.config.socket_path)?;
+        if let Some(ref p) = self.config.socket_path {
+            std::fs::remove_file(p)?;
+        }
         Ok(false)
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -8,7 +8,7 @@ use super::command::Command;
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct RecordingSession {
     input_device: String,
-    sample_rate: u32,
+    sample_rate: Option<u32>,
 }
 
 impl RecordingSession {
@@ -16,7 +16,7 @@ impl RecordingSession {
         &self.input_device
     }
 
-    pub fn sample_rate(&self) -> u32 {
+    pub fn sample_rate(&self) -> Option<u32> {
         self.sample_rate
     }
 }

--- a/src/audio/input.rs
+++ b/src/audio/input.rs
@@ -216,9 +216,11 @@ where
             c
         })
         .find_map(|c| {
-            if c.min_sample_rate() > SampleRate(session.sample_rate())
-                || c.max_sample_rate() < SampleRate(session.sample_rate())
-            {
+            let sample_rate = session
+                .sample_rate()
+                .map(SampleRate)
+                .unwrap_or_else(|| c.min_sample_rate().max(SampleRate(16000)));
+            if c.min_sample_rate() > sample_rate || c.max_sample_rate() < sample_rate {
                 None
             } else {
                 let min_sample_rate = c.min_sample_rate();


### PR DESCRIPTION

```
- fail if we don't have exactly one of the socket path/serve options
```